### PR TITLE
use: regex for address validation

### DIFF
--- a/src/utils/validator.js
+++ b/src/utils/validator.js
@@ -1,5 +1,3 @@
-import bs58check from "bs58check";
-
 export const matchList = [
   {
     text: ('passwordRequires'),
@@ -51,13 +49,5 @@ export function pwdConfirmValidate(pwd, confirmPwd) {
  * @param {*} address 
  */
 export function addressValid(address) {
-  try {
-    if (!address.toLowerCase().startsWith('b62')) {
-      return false;
-    }
-    const decodedAddress = bs58check.decode(address).toString('hex');
-    return !!decodedAddress && decodedAddress.length === 72;
-  } catch (ex) {
-    return false
-  }
+  return /^B62[1-9A-HJ-NP-Za-km-z]{52}$/.test(address);
 }


### PR DESCRIPTION
We don't have to use complex logic for address validation.
Using a regular expression, we can simplify the code and get rid of importing `bs58check` package in this file.
I've tested the regex with 10,000 generated addresses and it works as expected.
I've also manually tested mistaken addresses and it works as expected for them too.

Test code:

```js
import { PrivateKey } from "o1js"

function addressValid(address: string) {
    return /^B62[1-9A-HJ-NP-Za-km-z]{52}$/.test(address)
}

const table = []

for (let i = 0; i < 10000; i++) {
    const address = PrivateKey.random().toPublicKey().toBase58()
    const isValid = addressValid(address)
    table.push([address, isValid])
    if (!isValid) {
        throw Error(address)
    }
}

console.table(table)
```
