### PR TITLE
feat: add multi-provider discovery events

### DIFF
--- a/src/webHook/index.js
+++ b/src/webHook/index.js
@@ -1,2 +1,20 @@
-import MinaProvider from '@aurowallet/mina-provider';
-window.mina = new MinaProvider()
+import MinaProvider from "@aurowallet/mina-provider";
+const provider = new MinaProvider();
+const info = {
+  slug: "auro",
+  name: "Auro Wallet",
+  icon: "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwIiBoZWlnaHQ9IjEwMCIgdmlld0JveD0iMCAwIDEwMCAxMDAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik05MCAwSDEwQzQuNDc3MTUgMCAwIDQuNDc3MTUgMCAxMFY5MEMwIDk1LjUyMjkgNC40NzcxNSAxMDAgMTAgMTAwSDkwQzk1LjUyMjkgMTAwIDEwMCA5NS41MjI5IDEwMCA5MFYxMEMxMDAgNC40NzcxNSA5NS41MjI5IDAgOTAgMFoiIGZpbGw9IiM1OTRBRjEiLz4KPHBhdGggZD0iTTUwLjAwNzYgMTguMDk5NkM1NS42NDc2IDE4LjA5OTYgNjAuNTY3NiAxOS4yMDk2IDY0Ljc2NzYgMjEuNDI5NkM2OC45Njc2IDIzLjY0OTYgNzIuMjA3NiAyNi45NDk2IDc0LjQ4NzYgMzEuMzI5NkM3Ni44Mjc2IDM1LjY0OTYgNzcuOTk3NiA0MC44OTk2IDc3Ljk5NzYgNDcuMDc5NlY4MS45OTk2SDY2LjI5NzZWNjUuNzk5NkgzMy41Mzc2VjgxLjk5OTZIMjIuMDE3NlY0Ny4wNzk2QzIyLjAxNzYgNDAuODk5NiAyMy4xNTc2IDM1LjY0OTYgMjUuNDM3NiAzMS4zMjk2QzI3Ljc3NzYgMjYuOTQ5NiAzMS4wNDc2IDIzLjY0OTYgMzUuMjQ3NiAyMS40Mjk2QzM5LjQ0NzYgMTkuMjA5NiA0NC4zNjc2IDE4LjA5OTYgNTAuMDA3NiAxOC4wOTk2Wk02Ni4yOTc2IDU1Ljk4OTZWNDUuOTk5NkM2Ni4yOTc2IDQwLjE3OTYgNjQuODU3NiAzNS43OTk2IDYxLjk3NzYgMzIuODU5NkM1OS4wOTc2IDI5Ljg1OTYgNTUuMDc3NiAyOC4zNTk2IDQ5LjkxNzYgMjguMzU5NkM0NC43NTc2IDI4LjM1OTYgNDAuNzM3NiAyOS44NTk2IDM3Ljg1NzYgMzIuODU5NkMzNC45Nzc2IDM1Ljc5OTYgMzMuNTM3NiA0MC4xNzk2IDMzLjUzNzYgNDUuOTk5NlY1NS45ODk2SDY2LjI5NzZaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K",
+  rdns: "com.aurowallet.wallet",
+};
+window.mina = provider;
+const announceProvider = () => {
+  window.dispatchEvent(
+    new CustomEvent("mina:announceProvider", {
+      detail: Object.freeze({ info, provider }),
+    }),
+  );
+};
+window.addEventListener("mina:requestProvider", (event) => {
+  announceProvider();
+});
+announceProvider();


### PR DESCRIPTION
Changes:
- Adds EIP-6963 like wallet announcing events for the web provider, so zkApps can select a specific provider (the same standard is followed by Pallad).

![CleanShot 2024-07-01 at 11 31 50@2x](https://github.com/aurowallet/auro-wallet-browser-extension/assets/16132011/0f79efe9-3cb3-41de-b5d3-6ee84fb01f22)
![CleanShot 2024-07-01 at 11 33 31@2x](https://github.com/aurowallet/auro-wallet-browser-extension/assets/16132011/c4fc4a33-78cd-45f1-a8ae-9a05973182c4)
