### PR TITLE
feat: remove name parameter check in addChain action

### DIFF
--- a/src/background/DappService.js
+++ b/src/background/DappService.js
@@ -263,7 +263,7 @@ class DappService {
         }
         if(sendAction === DAppActions.mina_addChain){
           const realAddUrl = decodeURIComponent(params.url)
-          if (!urlValid(realAddUrl) || !params.name) {
+          if (!urlValid(realAddUrl)) {
             reject({ code:errorCodes.invalidParams, message: getMessageFromCode(errorCodes.invalidParams)})
             return
           }


### PR DESCRIPTION
Hi
I checked the code and didn't find any reason why requiring the name parameter when adding a chain is necessary, so I suggest removing it.